### PR TITLE
feat: add property to enable annotation rendering on Android

### DIFF
--- a/AndroidPdfViewer.d.ts
+++ b/AndroidPdfViewer.d.ts
@@ -37,6 +37,7 @@ declare class Configurator {
   load(): void;
   defaultPage(pageNumber: number): this;
   pages(...pageNumbers: number[]): this;
+  enableAnnotationRendering(enable: boolean): this;
   enableDoubletap(enable: boolean): this;
   enableSwipe(enable: boolean): this;
   fitEachPage(enable: boolean): this;

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -4,6 +4,6 @@
  loaded="pageLoaded">
   <FlexboxLayout flexDirection="column">
     <Button height="70" text="Show Another!" tap="{{ changePDF }}" />
-    <pdf:PDFView flexGrow="1" src="{{ pdfUrl }}" load="{{ onLoad }}" />
+    <pdf:PDFView flexGrow="1" src="{{ pdfUrl }}" load="{{ onLoad }}" enableAnnotationRendering="{{ enableAnnotationRendering }}" />
   </FlexboxLayout>
 </Page>

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -23,4 +23,5 @@ export class MainViewModel extends Observable {
   }
 
   private current = 0;
+  private enableAnnotationRendering = true;
 }

--- a/pdf-view.android.ts
+++ b/pdf-view.android.ts
@@ -60,6 +60,7 @@ export class PDFView extends PDFViewCommon {
       .fromUri(uri)
       .onLoad(this.onLoadHandler)
       .spacing(defaultSpacingDP)
+      .enableAnnotationRendering(this.enableAnnotationRendering)
       .fitEachPage(true)
       .load();
   }

--- a/pdf-view.common.d.ts
+++ b/pdf-view.common.d.ts
@@ -1,7 +1,9 @@
 import { Property, View } from 'tns-core-modules/ui/core/view';
 export declare abstract class PDFViewCommon extends View {
+    enableAnnotationRendering: boolean;
     static loadEvent: string;
     src: string;
     static notifyOfEvent(eventName: string, pdfViewRef: WeakRef<PDFViewCommon>): void;
 }
+export declare const enableAnnotationRenderingProperty: Property<PDFViewCommon, boolean>;
 export declare const srcProperty: Property<PDFViewCommon, string>;

--- a/pdf-view.common.ts
+++ b/pdf-view.common.ts
@@ -6,6 +6,11 @@ export abstract class PDFViewCommon extends View {
   public static loadEvent = 'load';
 
   /**
+   * Render annotations (such as comments, colors or forms) on Android
+   */
+  public enableAnnotationRendering: boolean;
+
+  /**
    * the source url of the PDF to show
    */
   public src: string;
@@ -21,6 +26,12 @@ export abstract class PDFViewCommon extends View {
     }
   }
 }
+
+export const enableAnnotationRenderingProperty = new Property<PDFViewCommon, boolean>({
+  name: 'enableAnnotationRendering',
+  defaultValue: false,
+});
+enableAnnotationRenderingProperty.register(PDFViewCommon);
 
 export const srcProperty = new Property<PDFViewCommon, string>({
   name: 'src',


### PR DESCRIPTION
By default the rendering of annotations is disabled in AndroidPdfViewer. As a result filled forms are not visible which is essential for my use case.
My PR adds an optional parameter which allows enabling the rendering of form context if desired. For iOS this parameter has no effect.